### PR TITLE
fix some issues with the types

### DIFF
--- a/nodejs_wheel/executable.py
+++ b/nodejs_wheel/executable.py
@@ -3,31 +3,43 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from typing import Any, Literal, overload, Iterable
+from typing import Any, Iterable, Literal, overload
 
 ROOT_DIR = os.path.dirname(__file__)
 
 
 @overload
 def _program(
-    name: str, args: Iterable[str], return_completed_process: Literal[True], **kwargs: Any
+    name: str,
+    args: Iterable[str],
+    return_completed_process: Literal[True],
+    **kwargs: Any,
 ) -> subprocess.CompletedProcess[str | bytes]: ...
 
 
 @overload
 def _program(
-    name: str, args: Iterable[str], return_completed_process: Literal[False] = ..., **kwargs: Any
+    name: str,
+    args: Iterable[str],
+    return_completed_process: Literal[False] = ...,
+    **kwargs: Any,
 ) -> subprocess.CompletedProcess[str | bytes]: ...
 
 
 @overload
 def _program(
-    name: str, args: Iterable[str], return_completed_process: bool = False, **kwargs: Any
+    name: str,
+    args: Iterable[str],
+    return_completed_process: bool = False,
+    **kwargs: Any,
 ) -> int | subprocess.CompletedProcess[str | bytes]: ...
 
 
 def _program(
-    name: str, args: Iterable[str], return_completed_process: bool = False, **kwargs: Any
+    name: str,
+    args: Iterable[str],
+    return_completed_process: bool = False,
+    **kwargs: Any,
 ) -> int | subprocess.CompletedProcess[str | bytes]:
     bin_dir = ROOT_DIR if os.name == "nt" else os.path.join(ROOT_DIR, "bin")
     complete_process = subprocess.run([os.path.join(bin_dir, name), *args], **kwargs)
@@ -74,18 +86,24 @@ def node(
 
 @overload
 def node(
-    args: Iterable[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
+    args: Iterable[str] | None,
+    return_completed_process: Literal[False] = ...,
+    **kwargs: Any,
 ) -> int: ...
 
 
 @overload
 def node(
-    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None,
+    return_completed_process: bool = False,
+    **kwargs: Any,
 ) -> int | subprocess.CompletedProcess[str | bytes]: ...
 
 
 def node(
-    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None,
+    return_completed_process: bool = False,
+    **kwargs: Any,
 ) -> int | subprocess.CompletedProcess[str | bytes]:
     """Call the node executable with the given arguments.
 
@@ -117,18 +135,24 @@ def npm(
 
 @overload
 def npm(
-    args: Iterable[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
+    args: Iterable[str] | None,
+    return_completed_process: Literal[False] = ...,
+    **kwargs: Any,
 ) -> int: ...
 
 
 @overload
 def npm(
-    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None,
+    return_completed_process: bool = False,
+    **kwargs: Any,
 ) -> int | subprocess.CompletedProcess[str | bytes]: ...
 
 
 def npm(
-    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None,
+    return_completed_process: bool = False,
+    **kwargs: Any,
 ) -> int | subprocess.CompletedProcess[str | bytes]:
     """Call the npm executable with the given arguments.
 
@@ -165,18 +189,24 @@ def npx(
 
 @overload
 def npx(
-    args: Iterable[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
+    args: Iterable[str] | None,
+    return_completed_process: Literal[False] = ...,
+    **kwargs: Any,
 ) -> int: ...
 
 
 @overload
 def npx(
-    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None,
+    return_completed_process: bool = False,
+    **kwargs: Any,
 ) -> int | subprocess.CompletedProcess[str | bytes]: ...
 
 
 def npx(
-    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None,
+    return_completed_process: bool = False,
+    **kwargs: Any,
 ) -> int | subprocess.CompletedProcess[str | bytes]:
     """Call the npx executable with the given arguments.
 

--- a/nodejs_wheel/executable.py
+++ b/nodejs_wheel/executable.py
@@ -3,31 +3,31 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from typing import Any, Literal, overload
+from typing import Any, Literal, overload, Iterable
 
 ROOT_DIR = os.path.dirname(__file__)
 
 
 @overload
 def _program(
-    name: str, args: list[str], return_completed_process: Literal[True], **kwargs: Any
+    name: str, args: Iterable[str], return_completed_process: Literal[True], **kwargs: Any
 ) -> subprocess.CompletedProcess[str | bytes]: ...
 
 
 @overload
 def _program(
-    name: str, args: list[str], return_completed_process: Literal[False] = ..., **kwargs: Any
+    name: str, args: Iterable[str], return_completed_process: Literal[False] = ..., **kwargs: Any
 ) -> subprocess.CompletedProcess[str | bytes]: ...
 
 
 @overload
 def _program(
-    name: str, args: list[str], return_completed_process: bool = False, **kwargs: Any
+    name: str, args: Iterable[str], return_completed_process: bool = False, **kwargs: Any
 ) -> int | subprocess.CompletedProcess[str | bytes]: ...
 
 
 def _program(
-    name: str, args: list[str], return_completed_process: bool = False, **kwargs: Any
+    name: str, args: Iterable[str], return_completed_process: bool = False, **kwargs: Any
 ) -> int | subprocess.CompletedProcess[str | bytes]:
     bin_dir = ROOT_DIR if os.name == "nt" else os.path.join(ROOT_DIR, "bin")
     complete_process = subprocess.run([os.path.join(bin_dir, name), *args], **kwargs)
@@ -68,24 +68,24 @@ def call_node(
 
 @overload
 def node(
-    args: list[str] | None, return_completed_process: Literal[True], **kwargs: Any
+    args: Iterable[str] | None, return_completed_process: Literal[True], **kwargs: Any
 ) -> subprocess.CompletedProcess[str | bytes]: ...
 
 
 @overload
 def node(
-    args: list[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
+    args: Iterable[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
 ) -> int: ...
 
 
 @overload
 def node(
-    args: list[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
 ) -> int | subprocess.CompletedProcess[str | bytes]: ...
 
 
 def node(
-    args: list[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
 ) -> int | subprocess.CompletedProcess[str | bytes]:
     """Call the node executable with the given arguments.
 
@@ -111,24 +111,24 @@ def node(
 
 @overload
 def npm(
-    args: list[str] | None, return_completed_process: Literal[True], **kwargs: Any
+    args: Iterable[str] | None, return_completed_process: Literal[True], **kwargs: Any
 ) -> subprocess.CompletedProcess[str | bytes]: ...
 
 
 @overload
 def npm(
-    args: list[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
+    args: Iterable[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
 ) -> int: ...
 
 
 @overload
 def npm(
-    args: list[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
 ) -> int | subprocess.CompletedProcess[str | bytes]: ...
 
 
 def npm(
-    args: list[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
 ) -> int | subprocess.CompletedProcess[str | bytes]:
     """Call the npm executable with the given arguments.
 
@@ -159,24 +159,24 @@ def npm(
 
 @overload
 def npx(
-    args: list[str] | None, return_completed_process: Literal[True], **kwargs: Any
+    args: Iterable[str] | None, return_completed_process: Literal[True], **kwargs: Any
 ) -> subprocess.CompletedProcess[str | bytes]: ...
 
 
 @overload
 def npx(
-    args: list[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
+    args: Iterable[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
 ) -> int: ...
 
 
 @overload
 def npx(
-    args: list[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
 ) -> int | subprocess.CompletedProcess[str | bytes]: ...
 
 
 def npx(
-    args: list[str] | None = None, return_completed_process: bool = False, **kwargs: Any
+    args: Iterable[str] | None = None, return_completed_process: bool = False, **kwargs: Any
 ) -> int | subprocess.CompletedProcess[str | bytes]:
     """Call the npx executable with the given arguments.
 

--- a/nodejs_wheel/executable.py
+++ b/nodejs_wheel/executable.py
@@ -16,7 +16,7 @@ def _program(
 
 @overload
 def _program(
-    name: str, args: list[str], return_completed_process: Literal[False], **kwargs: Any
+    name: str, args: list[str], return_completed_process: Literal[False] = ..., **kwargs: Any
 ) -> subprocess.CompletedProcess[str | bytes]: ...
 
 
@@ -44,7 +44,7 @@ def call_node(
 
 @overload
 def call_node(
-    *args: str, return_completed_process: Literal[False], **kwargs: Any
+    *args: str, return_completed_process: Literal[False] = ..., **kwargs: Any
 ) -> int: ...
 
 
@@ -74,7 +74,7 @@ def node(
 
 @overload
 def node(
-    args: list[str] | None, return_completed_process: Literal[False], **kwargs: Any
+    args: list[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
 ) -> int: ...
 
 
@@ -117,7 +117,7 @@ def npm(
 
 @overload
 def npm(
-    args: list[str] | None, return_completed_process: Literal[False], **kwargs: Any
+    args: list[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
 ) -> int: ...
 
 
@@ -165,7 +165,7 @@ def npx(
 
 @overload
 def npx(
-    args: list[str] | None, return_completed_process: Literal[False], **kwargs: Any
+    args: list[str] | None, return_completed_process: Literal[False] = ..., **kwargs: Any
 ) -> int: ...
 
 


### PR DESCRIPTION
- fix type error when the `return_completed_process` argument isn't specified, which was causing it to resolve to the wrong overload:
  ```py
  exit_code: int = node(["foo"]) # error: Expression of type "int | CompletedProcess[str | bytes]" is incompatible with declared type "int"
  ```
- change the type of `args` to `Iterable[str]` instead of `list[str]`, which is more flexible. for example, when wrapping it with a function that passes it a tuple:
  ```py
  def run_node(*args: str)
      node(args) # error: Argument of type "tuple[str, ...]" cannot be assigned to parameter "args" of type "list[str] | None"
  ```