### PR TITLE
 Update License Info with Well-known MIT Classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ description = "unoffical Node.js package"
 authors = [
   {name = "Jinzhe Zeng", email = "jinzhe.zeng@rutgers.edu"},
 ]
-license = {file = "LICENSE"}
 classifiers = [
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",


### PR DESCRIPTION
I am currently unable to utilize ``nodejs-wheel-binaries`` at my place of work because the (industry-standard) managed system we use to procure external code can not identify the license type.

This change replaces the current license property with the registered classifier for the MIT License, ensuring that it will be parsed properly by managed procurement tools like ours.

* Update license data in ``pyproject.toml``, replacing ``license`` property with the ``License :: OSI Approved :: MIT License`` entry in ``classifiers``.