### PR TITLE
fix: add typing-extensions to dependencies for Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Environment :: Console",
 ]
 dependencies = [
+    "typing-extensions;python_version<'3.8'",
 ]
 requires-python = ">=3.7"
 readme = "README.md"


### PR DESCRIPTION
Previously it was ignored, maybe due to Python 3.7 went EOL long long ago.