### PR TITLE
feat: Add Windows ARM64 support

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -44,11 +44,15 @@ jobs:
           - os: ARM64
             python: 311
             platform_id: manylinux_aarch64
+          # windows-arm64
+          - os: windows-latest
+            python: 311
+            platform_id: win_arm64
 
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/setup-nasm@v1
-        if: matrix.platform_id == 'win_amd64'
+        if: matrix.platform_id == 'win_amd64' || matrix.platform_id == 'win_arm64'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,12 +23,45 @@ if (UNIX)
         USES_TERMINAL_INSTALL true
         USES_TERMINAL_TEST true
     )
-elseif(WIN32)
+elseif(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
     ExternalProject_Add(nodejs
         URL https://github.com/nodejs/node/archive/refs/tags/v${CMAKE_PROJECT_VERSION}.tar.gz
         CONFIGURE_COMMAND ""
         BUILD_IN_SOURCE 1
         BUILD_COMMAND <SOURCE_DIR>/vcbuild
+        INSTALL_COMMAND ""
+        SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/nodejs_source
+        USES_TERMINAL_DOWNLOAD true
+        USES_TERMINAL_UPDATE true
+        USES_TERMINAL_PATCH true
+        USES_TERMINAL_CONFIGURE true
+        USES_TERMINAL_BUILD true
+        USES_TERMINAL_INSTALL true
+        USES_TERMINAL_TEST true
+    )
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/nodejs_source/out/Release/node.exe
+        DESTINATION ${SKBUILD_PLATLIB_DIR}/nodejs_wheel
+        PERMISSIONS
+        OWNER_READ
+        OWNER_WRITE
+        OWNER_EXECUTE
+        GROUP_READ
+        GROUP_EXECUTE
+        WORLD_READ
+        WORLD_EXECUTE
+    )
+    install(
+        DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/nodejs_source/deps/npm
+        DESTINATION ${SKBUILD_PLATLIB_DIR}/nodejs_wheel/lib/node_modules/
+        USE_SOURCE_PERMISSIONS
+    )
+elseif(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+    ExternalProject_Add(nodejs
+        URL https://github.com/nodejs/node/archive/refs/tags/v${CMAKE_PROJECT_VERSION}.tar.gz
+        CONFIGURE_COMMAND ""
+        BUILD_IN_SOURCE 1
+        BUILD_COMMAND <SOURCE_DIR>/vcbuild arm64
         INSTALL_COMMAND ""
         SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/nodejs_source
         USES_TERMINAL_DOWNLOAD true


### PR DESCRIPTION
Fix #87.

Add support for Windows ARM64 cross-compilation.

* **CMakeLists.txt**
  - Add a new `elseif` block for `WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64"` to handle Windows ARM64 builds.
  - Set the `BUILD_COMMAND` to `./vcbuild arm64` for Windows ARM64 builds.
  - Set the `INSTALL_COMMAND` to an empty string for Windows ARM64 builds.
  - Add an `install` command to copy the `node.exe` file to the appropriate destination for Windows ARM64 builds.
  - Add an `install` command to copy the `npm` directory to the appropriate destination for Windows ARM64 builds.

* **.github/workflows/build_wheel.yml**
  - Add a new matrix entry for Windows ARM64 builds with `os: windows-latest` and `platform_id: win_arm64`.
  - Add a condition to the `ilammy/setup-nasm@v1` step to include `matrix.platform_id == 'win_arm64'`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/njzjz/nodejs-wheel/pull/91?shareId=127f29b4-7a5a-4aeb-882f-a853583447a7).