### PR TITLE
CI: switch linux_aarch64 to GitHub hosted runners

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -41,7 +41,7 @@ jobs:
             python: 311
             platform_id: win_amd64
           # linux-aarch64
-          - os: ARM64
+          - os: ubuntu-24.04-arm
             python: 311
             platform_id: manylinux_aarch64
           # windows-arm64


### PR DESCRIPTION
See https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/