### PR TITLE
CI: Replace the macos-13 images with the macos-15-intel images

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -29,7 +29,7 @@ jobs:
             python: 311
             platform_id: musllinux_x86_64
           # macos-x86-64
-          - os: macos-13
+          - os: macos-15-intel
             python: 311
             platform_id: macosx_x86_64
           # macos-x86-64


### PR DESCRIPTION
per https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/